### PR TITLE
Units leave group when unconscious

### DIFF
--- a/source/anrop/ace_server/config.cpp
+++ b/source/anrop/ace_server/config.cpp
@@ -69,6 +69,12 @@ class ACE_ServerSettings {
         force = 1;
     };
 
+    class ace_medical_moveUnitsFromGroupOnUnconscious {
+        value = 1;
+        typeName = "BOOL";
+        force = 1;
+    };
+
     class ace_overheating_unJamOnreload {
         value = 1;
         typeName = "BOOL";


### PR DESCRIPTION
Gör det svårare att veta om en spelare är död eller inte, Skapar dessutom lite bätte AI-beteende.